### PR TITLE
Calling `UICollectionViewCell.canBecomeFocused` from within `DTCollectionViewDelegate.canFocusItemAt` can create an infinite recursion.

### DIFF
--- a/Source/DTCollectionViewDelegate.swift
+++ b/Source/DTCollectionViewDelegate.swift
@@ -178,7 +178,7 @@ open class DTCollectionViewDelegate: DTCollectionViewDelegateWrapper, UICollecti
         if let should = performCellReaction(.canFocusItemAtIndexPath, location: indexPath, provideCell: true) as? Bool {
             return should
         }
-        return (delegate as? UICollectionViewDelegate)?.collectionView?(collectionView, canFocusItemAt: indexPath) ?? collectionView.cellForItem(at: indexPath)?.canBecomeFocused ?? true
+        return (delegate as? UICollectionViewDelegate)?.collectionView?(collectionView, canFocusItemAt: indexPath) ?? true
     }
     
     /// Implementation of `UICollectionViewDelegateFlowLayout` and `UICollectionViewDelegate` protocol.


### PR DESCRIPTION
Saw an issue where the delegate routine for `canFocus` could be called recursively, until a crash. Issue was mis-filed over in the `DTTableViewManager` project (sorry!). https://github.com/DenHeadless/DTTableViewManager/issues/64

When calling the cell's `canBecomeFocused` routine, it _may_ call the delegate's `canFocusItemAt` routuine (the routine where this change is). To avoid this, we're removing the call to `canBecomeFocused` here.